### PR TITLE
feat: automate the releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  commitlint:
+    name: Lint Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5
+
   doc:
     name: Build Doc
     runs-on: ubuntu-latest

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,87 @@
+---
+name: CI on Master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build the project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - name: run cargo build
+        run: cargo build --all-features
+
+  get-next-version:
+    name: Get the next version
+    runs-on: ubuntu-latest
+    outputs:
+      version : ${{ steps.semantic-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: paulhatch/semantic-version@976ff820fcdca81ffc95e385a07b7eff05ddccc3
+        id: semantic-version
+        with:
+          tag_prefix: "v"
+          major_pattern: "/^breaking change:/"
+          major_regexp_flags: "ig"
+          minor_pattern: "/^feat:/"
+          minor_regexp_flags: "ig"
+          version_format: "${major}.${minor}.${patch}"
+          bump_each_commit: false
+          search_commit_body: true
+          enable_prerelease_mode: true
+
+  release:
+    name: Publish a new release
+    needs:
+      - get-next-version
+      - build
+    permissions:
+      # This permission is required in order to push the new
+      # tag to the repository.
+      contents: write
+    runs-on: ubuntu-latest
+    env:
+      next-version: ${{ needs.get-next-version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Print the next version
+        run: |
+          echo "The next version is ${{ env.next-version }}"
+
+      - name: Patch the Cargo version
+        run: |
+          sed -i 's/0.0.0-placeholder-version/${{ env.next-version }}/' Cargo.toml
+          git diff
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Publish new Cargo version
+        env:
+          # This token needs to be created with the publish-update scope.
+          # The other scopes are not necessary.
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --allow-dirty
+
+      - name: Tag the next version
+        run: |
+          new_tag_name="v${{ env.next-version }}"
+          git tag "$new_tag_name" "${{ github.sha }}"
+          git push origin "$new_tag_name"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "challenge_response"
-version = "0.0.1"
+version = "0.0.0-placeholder-version"
 authors = ["Ashutosh Varma <github@ashu.io>", "louib <code@louib.net>"]
 
 description = "Challenge-Response library for Rust"


### PR DESCRIPTION
This should be enough to automate the release process. The new version will be determined by the commit messages in the release, based on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). I manually pushed the `0.0.1` tag to make sure that the next version is correctly detected. I also already populated the cargo token in the GH secrets.