### PR TITLE
ci: relax breaking change detection

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -28,11 +28,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: paulhatch/semantic-version@976ff820fcdca81ffc95e385a07b7eff05ddccc3
+      - uses: paulhatch/semantic-version@e528d273e7da55ef59a0987c2ad7b8bcbc09698e
         id: semantic-version
         with:
           tag_prefix: "v"
-          major_pattern: "/^breaking change:/"
+          major_pattern: "/breaking change:/"
           major_regexp_flags: "ig"
           minor_pattern: "/^feat:/"
           minor_regexp_flags: "ig"


### PR DESCRIPTION
With the previous regex, the `BREAKING CHANGE:` string would only get detected when at the beginning of the commit description. This commit should allow the breaking changes to be documented anywhere in the commit description.