### PR TITLE
refactor: deprecate the find_yubikey function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ use rand::distributions::{Alphanumeric};
 fn main() {
    let mut yubi = Yubico::new();
 
-   if let Ok(device) = yubi.find_yubikey() {
+   if let Ok(devices) = yubi.find_all_yubikeys() {
+       let device = devices[0].clone();
        println!("Vendor ID: {:?} Product ID {:?}", device.vendor_id, device.product_id);
 
        let config = Config::new_from(device)
@@ -95,7 +96,8 @@ use challenge_response::config::{Config, Slot, Mode};
 fn main() {
    let mut yubi = Yubico::new();
 
-   if let Ok(device) = yubi.find_yubikey() {
+   if let Ok(devices) = yubi.find_all_yubikeys() {
+       let device = devices[0].clone();
        println!("Vendor ID: {:?} Product ID {:?}", device.vendor_id, device.product_id);
 
        let config = Config::new_from(device)

--- a/examples/challenge_response_hmac.rs
+++ b/examples/challenge_response_hmac.rs
@@ -8,7 +8,8 @@ use std::ops::Deref;
 fn main() {
     let mut yubi = Yubico::new();
 
-    if let Ok(device) = yubi.find_yubikey() {
+    if let Ok(devices) = yubi.find_all_yubikeys() {
+        let device = devices[0].clone();
         println!(
             "Vendor ID: {:?} Product ID {:?}",
             device.vendor_id, device.product_id

--- a/examples/challenge_response_otp.rs
+++ b/examples/challenge_response_otp.rs
@@ -7,7 +7,8 @@ use challenge_response::Yubico;
 fn main() {
     let mut yubi = Yubico::new();
 
-    if let Ok(device) = yubi.find_yubikey() {
+    if let Ok(devices) = yubi.find_all_yubikeys() {
+        let device = devices[0].clone();
         println!(
             "Vendor ID: {:?} Product ID {:?}",
             device.vendor_id, device.product_id

--- a/examples/configuration_hmac.rs
+++ b/examples/configuration_hmac.rs
@@ -11,7 +11,8 @@ use rand::{thread_rng, Rng};
 fn main() {
     let mut yubi = Yubico::new();
 
-    if let Ok(device) = yubi.find_yubikey() {
+    if let Ok(devices) = yubi.find_all_yubikeys() {
+        let device = devices[0].clone();
         println!(
             "Vendor ID: {:?} Product ID {:?}",
             device.vendor_id, device.product_id

--- a/examples/configuration_otp.rs
+++ b/examples/configuration_otp.rs
@@ -8,7 +8,8 @@ use challenge_response::Yubico;
 fn main() {
     let mut yubi = Yubico::new();
 
-    if let Ok(device) = yubi.find_yubikey() {
+    if let Ok(devices) = yubi.find_all_yubikeys() {
+        let device = devices[0].clone();
         println!(
             "Vendor ID: {:?} Product ID {:?}",
             device.vendor_id, device.product_id

--- a/examples/serial_number.rs
+++ b/examples/serial_number.rs
@@ -7,7 +7,8 @@ use challenge_response::Yubico;
 fn main() {
     let mut yubi = Yubico::new();
 
-    if let Ok(device) = yubi.find_yubikey() {
+    if let Ok(devices) = yubi.find_all_yubikeys() {
+        let device = devices[0].clone();
         println!(
             "Vendor ID: {:?} Product ID {:?}",
             device.vendor_id, device.product_id

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,28 +90,6 @@ impl Yubico {
         Ok(serial.0)
     }
 
-    pub fn find_yubikey(&mut self) -> Result<Yubikey> {
-        for device in self.context.devices().unwrap().iter() {
-            let descr = device.device_descriptor().unwrap();
-            if descr.vendor_id() == YUBICO_VENDOR_ID && YUBIKEY_DEVICE_ID.contains(&descr.product_id()) {
-                let name = device.open()?.read_product_string_ascii(&descr).ok();
-                let serial = self.read_serial_from_device(device.clone()).ok();
-                let yubikey = Yubikey {
-                    name: name,
-                    serial: serial,
-                    product_id: descr.product_id(),
-                    vendor_id: descr.vendor_id(),
-                    bus_id: device.bus_number(),
-                    address_id: device.address(),
-                };
-
-                return Ok(yubikey);
-            }
-        }
-
-        Err(YubicoError::DeviceNotFound)
-    }
-
     pub fn find_yubikey_from_serial(&mut self, serial: u32) -> Result<Yubikey> {
         for device in self.context.devices().unwrap().iter() {
             let descr = device.device_descriptor().unwrap();


### PR DESCRIPTION
Now that we have the `find_all_yubikeys` function, I don't think there's any need to preserve the previous function, especially since it defaults to returning the first yubikey. This behavior can be unexpected, would have to be documented, and can be re-implemented using the `find_all_yubikeys` function.

BREAKING CHANGE: The `find_yubikey` function has been removed in favor of the `find_all_yubikeys` function.