### PR TITLE
 refactor: avoid panicking when creating new Yubico instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,14 @@ jobs:
 
       - name: Build the examples
         run: cargo build --examples
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - name: run cargo test
+        run: cargo test --all-features

--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ use rand::{thread_rng, Rng};
 use rand::distributions::{Alphanumeric};
 
 fn main() {
-   let mut yubi = Yubico::new();
+   let mut yubi = match Yubico::new() {
+       Ok(y) => y,
+       Err(e) => {
+           eprintln!("{}", e.to_string());
+           return;
+       },
+   };
 
    if let Ok(device) = yubi.find_yubikey() {
        println!("Vendor ID: {:?} Product ID {:?}", device.vendor_id, device.product_id);
@@ -66,8 +72,8 @@ fn main() {
 
         // Secret must have 20 bytes
         // Used rand here, but you can set your own secret: let secret: &[u8; 20] = b"my_awesome_secret_20";
-        let secret: String = rng.sample_iter(&Alphanumeric).take(20).collect();
-        let hmac_key: HmacKey = HmacKey::from_slice(secret.as_bytes());
+        let secret: Vec<u8> = rng.sample_iter(&Alphanumeric).take(20).collect();
+        let hmac_key: HmacKey = HmacKey::from_slice(&secret);
 
         let mut device_config = DeviceModeConfig::default();
         device_config.challenge_response_hmac(&hmac_key, false, false);
@@ -97,7 +103,13 @@ use challenge_response::{Yubico};
 use challenge_response::config::{Config, Slot, Mode};
 
 fn main() {
-   let mut yubi = Yubico::new();
+   let mut yubi = match Yubico::new() {
+       Ok(y) => y,
+       Err(e) => {
+           eprintln!("{}", e.to_string());
+           return;
+       },
+   };
 
    if let Ok(device) = yubi.find_yubikey() {
        println!("Vendor ID: {:?} Product ID {:?}", device.vendor_id, device.product_id);

--- a/examples/challenge_response_hmac.rs
+++ b/examples/challenge_response_hmac.rs
@@ -6,7 +6,7 @@ use challenge_response::Yubico;
 use std::ops::Deref;
 
 fn main() {
-    let mut yubi = Yubico::new();
+    let mut yubi = Yubico::new().unwrap();
 
     if let Ok(device) = yubi.find_yubikey() {
         println!(

--- a/examples/challenge_response_otp.rs
+++ b/examples/challenge_response_otp.rs
@@ -5,7 +5,7 @@ use challenge_response::config::{Config, Mode, Slot};
 use challenge_response::Yubico;
 
 fn main() {
-    let mut yubi = Yubico::new();
+    let mut yubi = Yubico::new().unwrap();
 
     if let Ok(device) = yubi.find_yubikey() {
         println!(

--- a/examples/configuration_hmac.rs
+++ b/examples/configuration_hmac.rs
@@ -9,7 +9,7 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 
 fn main() {
-    let mut yubi = Yubico::new();
+    let mut yubi = Yubico::new().unwrap();
 
     if let Ok(device) = yubi.find_yubikey() {
         println!(

--- a/examples/configuration_otp.rs
+++ b/examples/configuration_otp.rs
@@ -6,7 +6,7 @@ use challenge_response::otpmode::Aes128Key;
 use challenge_response::Yubico;
 
 fn main() {
-    let mut yubi = Yubico::new();
+    let mut yubi = Yubico::new().unwrap();
 
     if let Ok(device) = yubi.find_yubikey() {
         println!(

--- a/examples/serial_number.rs
+++ b/examples/serial_number.rs
@@ -5,7 +5,7 @@ use challenge_response::config::{Config, Slot};
 use challenge_response::Yubico;
 
 fn main() {
-    let mut yubi = Yubico::new();
+    let mut yubi = Yubico::new().unwrap();
 
     if let Ok(device) = yubi.find_yubikey() {
         println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 extern crate rusb;
 
 #[macro_use]
@@ -57,10 +58,12 @@ pub struct Yubico {
 
 impl Yubico {
     /// Creates a new Yubico instance.
-    pub fn new() -> Self {
-        Yubico {
-            context: Context::new().unwrap(),
-        }
+    pub fn new() -> Result<Self> {
+        let context = match Context::new() {
+            Ok(c) => c,
+            Err(e) => return Err(YubicoError::UsbError(e)),
+        };
+        Ok(Yubico { context })
     }
 
     fn read_serial_from_device(&mut self, device: rusb::Device<Context>) -> Result<u32> {


### PR DESCRIPTION
The README examples were also broken, so I'm fixing them at the same
time.

BREAKING CHANGE: Creating a new instance of `Yubico` now returns a
Response to avoid panicking if the usb devices cannot be polled.