### PR TITLE
refactor: hide sec module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod error;
 pub mod hmacmode;
 mod manager;
 pub mod otpmode;
-pub mod sec;
+mod sec;
 
 use aes::cipher::generic_array::GenericArray;
 


### PR DESCRIPTION
I don't think there's any real need to make this module public, since it is only a set of utility functions used internally.

BREAKING CHANGE: The sec module was made private