### PR TITLE
refactor: extract hmac secret length

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ extern crate rand;
 
 use challenge_response::config::{Command, Config};
 use challenge_response::configure::DeviceModeConfig;
-use challenge_response::hmacmode::HmacKey;
+use challenge_response::hmacmode::{HMAC_SECRET_SIZE, HmacKey};
 use challenge_response::ChallengeResponse;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
@@ -137,11 +137,10 @@ fn main() {
 
     let mut rng = thread_rng();
 
-    // Secret must have 20 bytes
     // Used rand here, but you can set your own secret:
-    // let secret: &[u8; 20] = b"my_awesome_secret_20";
+    // let secret: &[u8; HMAC_SECRET_SIZE] = b"my_awesome_secret_20";
     let secret: Vec<u8> =
-        rng.sample_iter(&Alphanumeric).take(20).collect();
+        rng.sample_iter(&Alphanumeric).take(HMAC_SECRET_SIZE).collect();
     let hmac_key: HmacKey = HmacKey::from_slice(&secret);
 
     let mut device_config = DeviceModeConfig::default();

--- a/src/hmacmode.rs
+++ b/src/hmacmode.rs
@@ -2,8 +2,15 @@ use rand::Rng;
 use sec::hmac_sha1;
 use std;
 
+/// Size of the secret used by the HMAC algorithm
+pub const HMAC_SECRET_SIZE: usize = 20;
+
+/// Secret used to seed the HMAC algorithm
+pub type HmacSecret = [u8; HMAC_SECRET_SIZE];
+
 #[derive(Debug)]
-pub struct Hmac(pub [u8; 20]);
+pub struct Hmac(pub HmacSecret);
+
 impl Drop for Hmac {
     fn drop(&mut self) {
         for i in self.0.iter_mut() {
@@ -25,9 +32,9 @@ impl Hmac {
     }
 }
 
-/// A secret key for HMAC.
+/// A secret key for HMAC, derived from the HMAC secret
 #[derive(Debug)]
-pub struct HmacKey(pub [u8; 20]);
+pub struct HmacKey(pub HmacSecret);
 impl Drop for HmacKey {
     fn drop(&mut self) {
         for i in self.0.iter_mut() {
@@ -38,13 +45,13 @@ impl Drop for HmacKey {
 
 impl HmacKey {
     pub fn from_slice(s: &[u8]) -> Self {
-        let mut key = HmacKey([0; 20]);
+        let mut key = HmacKey([0; HMAC_SECRET_SIZE]);
         (&mut key.0).clone_from_slice(s);
         key
     }
 
     pub fn generate<R: Rng>(mut rng: R) -> Self {
-        let mut key = HmacKey([0; 20]);
+        let mut key = HmacKey([0; HMAC_SECRET_SIZE]);
         for i in key.0.iter_mut() {
             *i = rng.gen()
         }


### PR DESCRIPTION
This will avoid duplicating the secret length all over the place.