### PR TITLE
refactor: extract challenge size as a constant

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -48,7 +48,7 @@ const SIZEOF_CONFIG: usize = 52;
 impl DeviceModeConfig {
     #[doc(hidden)]
     pub fn to_frame(&mut self, command: Command) -> Frame {
-        let mut payload = [0; 64];
+        let mut payload = [0; crate::manager::PAYLOAD_SIZE];
         // First set CRC.
         self.crc = {
             let first_fields = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,10 @@ const PRODUCT_ID: [u16; 11] = [
     0x4211, // NitroKey
 ];
 
+/// If using a variable-length challenge, the challenge must be stricly smaller than this value.
+/// If using a fixed-length challenge, the challenge must be exactly equal to this value.
+pub const CHALLENGE_SIZE: usize = 64;
+
 /// The `Result` type used in this crate.
 type Result<T> = ::std::result::Result<T, ChallengeResponseError>;
 
@@ -75,7 +79,7 @@ impl ChallengeResponse {
     fn read_serial_from_device(&mut self, device: rusb::Device<Context>) -> Result<u32> {
         let (mut handle, interfaces) =
             manager::open_device(&mut self.context, device.bus_number(), device.address())?;
-        let challenge = [0; 64];
+        let challenge = [0; CHALLENGE_SIZE];
         let command = Command::DeviceSerial;
 
         let d = Frame::new(challenge, command); // FixMe: do not need a challange
@@ -221,7 +225,7 @@ impl ChallengeResponse {
     pub fn read_serial_number(&mut self, conf: Config) -> Result<u32> {
         match manager::open_device(&mut self.context, conf.device.bus_id, conf.device.address_id) {
             Ok((mut handle, interfaces)) => {
-                let challenge = [0; 64];
+                let challenge = [0; CHALLENGE_SIZE];
                 let command = Command::DeviceSerial;
 
                 let d = Frame::new(challenge, command); // FixMe: do not need a challange
@@ -257,10 +261,10 @@ impl ChallengeResponse {
 
         match manager::open_device(&mut self.context, conf.device.bus_id, conf.device.address_id) {
             Ok((mut handle, interfaces)) => {
-                let mut challenge = [0; 64];
+                let mut challenge = [0; CHALLENGE_SIZE];
 
                 if conf.variable && chall.last() == Some(&0) {
-                    challenge = [0xff; 64];
+                    challenge = [0xff; CHALLENGE_SIZE];
                 }
 
                 let mut command = Command::ChallengeHmac1;
@@ -304,8 +308,7 @@ impl ChallengeResponse {
 
         match manager::open_device(&mut self.context, conf.device.bus_id, conf.device.address_id) {
             Ok((mut handle, interfaces)) => {
-                let mut challenge = [0; 64];
-                //(&mut challenge[..6]).copy_from_slice(chall);
+                let mut challenge = [0; CHALLENGE_SIZE];
 
                 let mut command = Command::ChallengeOtp1;
                 if let Slot::Slot2 = conf.slot {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -5,7 +5,7 @@ use sec::crc16;
 use std::time::Duration;
 use std::{slice, thread};
 
-const DATA_SIZE: usize = 64;
+pub(crate) const PAYLOAD_SIZE: usize = 64;
 const HID_GET_REPORT: u8 = 0x01;
 const HID_SET_REPORT: u8 = 0x09;
 const REPORT_TYPE_FEATURE: u16 = 0x03;
@@ -196,14 +196,14 @@ pub fn read_response(
 #[repr(C)]
 #[repr(packed)]
 pub struct Frame {
-    pub payload: [u8; DATA_SIZE],
+    pub payload: [u8; PAYLOAD_SIZE],
     command: Command,
     crc: u16,
     filler: [u8; 3],
 }
 
 impl Frame {
-    pub fn new(payload: [u8; DATA_SIZE], command: Command) -> Self {
+    pub fn new(payload: [u8; PAYLOAD_SIZE], command: Command) -> Self {
         let mut f = Frame {
             payload,
             command,


### PR DESCRIPTION
I don't think the concepts of challenge size and payload size are exactly the same, which is why I kept both constants separate.