### PR TITLE
chore: do not run cr config example as a test

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ fn main() {
 Note, please read about the [initial configuration](https://wiki.archlinux.org/index.php/yubikey#Initial_configuration)
 Alternatively you can configure the yubikey with the official [Yubikey Personalization GUI](https://developers.yubico.com/yubikey-personalization-gui/).
 
-```rust
+```ignore
 extern crate challenge_response;
 extern crate rand;
 


### PR DESCRIPTION
Since the examples in the README by default will run on `cargo test`, we might accidentally reconfigure the yubikey of a developer that just wanted to run the unit test on their workstation. I think it's safer to ignore that example when running the tests