### PR TITLE
ci: configure code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,15 @@ jobs:
           toolchain: stable
       - name: run cargo test
         run: cargo test --all-features
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/xd009642/tarpaulin:0.31.0
+      options: --security-opt seccomp=unconfined
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify code coverage
+        run: |
+          cargo tarpaulin --verbose --timeout 120

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -7,6 +7,24 @@ on:
       - master
 
 jobs:
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/xd009642/tarpaulin:0.31.0
+      options: --security-opt seccomp=unconfined
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate code coverage
+        run: |
+          cargo tarpaulin --verbose --timeout 120
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarpaulin-report
+          path: tarpaulin-report.html
+
   build:
     name: Build the project
     runs-on: ubuntu-latest

--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,0 +1,7 @@
+[all]
+all-features = true
+workspace = true
+target-dir = "target/coverage/"
+fail-under = 1
+exclude-files = ["target/*"]
+out = ["Xml", "Html"]


### PR DESCRIPTION
This configures a code coverage check to verify the coverage level on PRs, and to verify + upload a coverage report when merging. Yes, the current threshold is 1% (We are currently at 1.02% coverage). It's gonna be hard not to go up from there!