### PR TITLE
feat: add nusb support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Build the project with all the features
         run: cargo build --all-features
 
+      - name: Build the project with nusb support
+        run: cargo build --no-default-features --features nusb
+
       - name: Build the examples
         run: cargo build --examples
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,16 @@ include = [
 name = "challenge_response"
 path = "src/lib.rs"
 
+[features]
+rusb = ["dep:rusb"]
+nusb = ["dep:nusb"]
+default = ["rusb"]
+
 [dependencies]
 rand = "0.8"
 bitflags = "2.4"
-rusb = "0.9"
+rusb = { version = "0.9", optional = true }
+nusb = { version = "0.1", optional = true }
 structure = "0.1"
 aes = "0.8"
 block-modes = "0.9"

--- a/README.md
+++ b/README.md
@@ -31,12 +31,24 @@
 
 ## Usage
 
-Add this to your Cargo.toml
+Add this to your `Cargo.toml`
 
 ```toml
 [dependencies]
 challenge_response = "0"
 ```
+
+### nusb backend (EXPERIMENTAL)
+
+You can enable the experimental [nusb](https://crates.io/crates/nusb) backend by adding the following to your `Cargo.toml` manifest:
+
+```toml
+[dependencies]
+challenge_response = { version = "0", default-features = false, features = ["nusb"] }
+```
+
+The `nusb` backend has the advantage of not depending on `libusb`, thus making it easier to add
+`challenge_response` to your dependencies.
 
 ### Perform a Challenge-Response (HMAC-SHA1 mode)
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "rusb")]
 use rusb::Error as usbError;
 use std::error;
 use std::fmt;
@@ -6,26 +7,32 @@ use std::io::Error as ioError;
 #[derive(Debug)]
 pub enum ChallengeResponseError {
     IOError(ioError),
+    #[cfg(feature = "rusb")]
     UsbError(usbError),
     CommandNotSupported,
     DeviceNotFound,
     OpenDeviceError,
     CanNotWriteToDevice,
+    CanNotReadFromDevice,
     WrongCRC,
     ConfigNotWritten,
+    ListDevicesError,
 }
 
 impl fmt::Display for ChallengeResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ChallengeResponseError::IOError(ref err) => write!(f, "IO error: {}", err),
+            #[cfg(feature = "rusb")]
             ChallengeResponseError::UsbError(ref err) => write!(f, "USB  error: {}", err),
             ChallengeResponseError::DeviceNotFound => write!(f, "Device not found"),
             ChallengeResponseError::OpenDeviceError => write!(f, "Can not open device"),
             ChallengeResponseError::CommandNotSupported => write!(f, "Command Not Supported"),
             ChallengeResponseError::WrongCRC => write!(f, "Wrong CRC"),
             ChallengeResponseError::CanNotWriteToDevice => write!(f, "Can not write to Device"),
+            ChallengeResponseError::CanNotReadFromDevice => write!(f, "Can not read from Device"),
             ChallengeResponseError::ConfigNotWritten => write!(f, "Configuration has failed"),
+            ChallengeResponseError::ListDevicesError => write!(f, "Could not list available devices"),
         }
     }
 }
@@ -33,6 +40,7 @@ impl fmt::Display for ChallengeResponseError {
 impl error::Error for ChallengeResponseError {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
+            #[cfg(feature = "rusb")]
             ChallengeResponseError::UsbError(ref err) => Some(err),
             _ => None,
         }
@@ -45,6 +53,7 @@ impl From<ioError> for ChallengeResponseError {
     }
 }
 
+#[cfg(feature = "rusb")]
 impl From<usbError> for ChallengeResponseError {
     fn from(err: usbError) -> ChallengeResponseError {
         ChallengeResponseError::UsbError(err)

--- a/src/usb/nusb.rs
+++ b/src/usb/nusb.rs
@@ -1,0 +1,87 @@
+use error::ChallengeResponseError;
+use nusb::Interface;
+use std::time::Duration;
+use usb::{DeviceHandle, HID_GET_REPORT, HID_SET_REPORT, REPORT_TYPE_FEATURE};
+
+pub fn open_device(
+    _context: &mut (),
+    bus_id: u8,
+    address_id: u8,
+) -> Result<(DeviceHandle, Vec<Interface>), ChallengeResponseError> {
+    let nusb_devices = match nusb::list_devices() {
+        Ok(d) => d,
+        Err(e) => return Err(e.into()),
+    };
+    for device_info in nusb_devices {
+        if device_info.bus_number() != bus_id || device_info.device_address() != address_id {
+            continue;
+        }
+
+        let device = match device_info.open() {
+            Ok(d) => d,
+            Err(_) => {
+                return Err(ChallengeResponseError::OpenDeviceError);
+            }
+        };
+
+        let mut interfaces: Vec<Interface> = Vec::new();
+        for interface in device_info.interfaces() {
+            let interface = match device.detach_and_claim_interface(interface.interface_number()) {
+                Ok(interface) => interface,
+                Err(_) => continue,
+            };
+
+            interfaces.push(interface);
+        }
+        return Ok((device, interfaces));
+    }
+
+    Err(ChallengeResponseError::DeviceNotFound)
+}
+
+pub fn close_device(
+    mut _handle: DeviceHandle,
+    _interfaces: Vec<Interface>,
+) -> Result<(), ChallengeResponseError> {
+    Ok(())
+}
+
+pub fn read(handle: &mut DeviceHandle, buf: &mut [u8]) -> Result<usize, ChallengeResponseError> {
+    assert_eq!(buf.len(), 8);
+
+    let control_type = nusb::transfer::ControlType::Class;
+    let control_in = nusb::transfer::Control {
+        control_type,
+        recipient: nusb::transfer::Recipient::Interface,
+        request: HID_GET_REPORT,
+        value: REPORT_TYPE_FEATURE << 8,
+        index: 0,
+    };
+
+    match handle.control_in_blocking(control_in, buf, Duration::new(2, 0)) {
+        Ok(r) => Ok(r),
+        Err(_e) => Err(ChallengeResponseError::CanNotReadFromDevice),
+    }
+}
+
+pub fn raw_write(handle: &mut DeviceHandle, packet: &[u8]) -> Result<(), ChallengeResponseError> {
+    let control_type = nusb::transfer::ControlType::Class;
+    let control_out = nusb::transfer::Control {
+        control_type,
+        recipient: nusb::transfer::Recipient::Interface,
+        request: HID_SET_REPORT,
+        value: REPORT_TYPE_FEATURE << 8,
+        index: 0,
+    };
+
+    match handle.control_out_blocking(control_out, packet, Duration::new(2, 0)) {
+        Ok(bytes_written) => {
+            if bytes_written != 8 {
+                Err(ChallengeResponseError::CanNotWriteToDevice)
+            } else {
+                Ok(())
+            }
+        }
+        Err(_) => Err(ChallengeResponseError::CanNotWriteToDevice),
+    }
+}


### PR DESCRIPTION
By default, the `rusb` backend will be used, in order to to preserve the current behavior. There is still one direct reference to a component of the `rusb` library from `lib.rs` (`rusb::UsbContext`), but apart from that, all references to `nusb` or `rusb` are located within the `usb` sub-module.

Fixes https://github.com/louib/challenge-response/issues/25