### PR TITLE
refactor: move common usb components to separate module

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,9 +1,9 @@
 use config::Command;
 use hmacmode::HmacKey;
-use manager::Frame;
 use otpmode::Aes128Key;
 use sec::crc16;
 use std;
+use usb::{Frame, PAYLOAD_SIZE};
 
 const FIXED_SIZE: usize = 16;
 const UID_SIZE: usize = 6;
@@ -48,7 +48,7 @@ const SIZEOF_CONFIG: usize = 52;
 impl DeviceModeConfig {
     #[doc(hidden)]
     pub fn to_frame(&mut self, command: Command) -> Frame {
-        let mut payload = [0; crate::manager::PAYLOAD_SIZE];
+        let mut payload = [0; PAYLOAD_SIZE];
         // First set CRC.
         self.crc = {
             let first_fields = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod hmacmode;
 mod manager;
 pub mod otpmode;
 mod sec;
+mod usb;
 
 use aes::cipher::generic_array::GenericArray;
 
@@ -27,10 +28,10 @@ use config::{Config, Slot};
 use configure::DeviceModeConfig;
 use error::ChallengeResponseError;
 use hmacmode::Hmac;
-use manager::{Flags, Frame};
 use otpmode::Aes128Block;
 use rusb::{Context, UsbContext};
 use sec::{crc16, CRC_RESIDUAL_OK};
+use usb::{Flags, Frame};
 
 const VENDOR_ID: [u16; 3] = [
     0x1050, // Yubico ( Yubikeys )
@@ -83,13 +84,13 @@ impl ChallengeResponse {
         let command = Command::DeviceSerial;
 
         let d = Frame::new(challenge, command); // FixMe: do not need a challange
-        let mut buf = [0; manager::STATUS_UPDATE_PAYLOAD_SIZE];
+        let mut buf = [0; usb::STATUS_UPDATE_PAYLOAD_SIZE];
         manager::wait(&mut handle, |f| !f.contains(Flags::SLOT_WRITE_FLAG), &mut buf)?;
 
         manager::write_frame(&mut handle, &d)?;
 
         // Read the response.
-        let mut response = [0; manager::RESPONSE_SIZE];
+        let mut response = [0; usb::RESPONSE_SIZE];
         manager::read_response(&mut handle, &mut response)?;
         manager::close_device(handle, interfaces)?;
 
@@ -204,7 +205,7 @@ impl ChallengeResponse {
 
     pub fn write_config(&mut self, conf: Config, device_config: &mut DeviceModeConfig) -> Result<()> {
         let d = device_config.to_frame(conf.command);
-        let mut buf = [0; manager::STATUS_UPDATE_PAYLOAD_SIZE];
+        let mut buf = [0; usb::STATUS_UPDATE_PAYLOAD_SIZE];
 
         let (mut handle, interfaces) =
             manager::open_device(&mut self.context, conf.device.bus_id, conf.device.address_id)?;
@@ -228,17 +229,17 @@ impl ChallengeResponse {
         let command = Command::DeviceSerial;
 
         let d = Frame::new(challenge, command); // FixMe: do not need a challange
-        let mut buf = [0; manager::STATUS_UPDATE_PAYLOAD_SIZE];
+        let mut buf = [0; usb::STATUS_UPDATE_PAYLOAD_SIZE];
         manager::wait(
             &mut handle,
-            |f| !f.contains(manager::Flags::SLOT_WRITE_FLAG),
+            |f| !f.contains(usb::Flags::SLOT_WRITE_FLAG),
             &mut buf,
         )?;
 
         manager::write_frame(&mut handle, &d)?;
 
         // Read the response.
-        let mut response = [0; manager::RESPONSE_SIZE];
+        let mut response = [0; usb::RESPONSE_SIZE];
         manager::read_response(&mut handle, &mut response)?;
         manager::close_device(handle, interfaces)?;
 
@@ -271,17 +272,17 @@ impl ChallengeResponse {
 
         (&mut challenge[..chall.len()]).copy_from_slice(chall);
         let d = Frame::new(challenge, command);
-        let mut buf = [0; manager::STATUS_UPDATE_PAYLOAD_SIZE];
+        let mut buf = [0; usb::STATUS_UPDATE_PAYLOAD_SIZE];
         manager::wait(
             &mut handle,
-            |f| !f.contains(manager::Flags::SLOT_WRITE_FLAG),
+            |f| !f.contains(usb::Flags::SLOT_WRITE_FLAG),
             &mut buf,
         )?;
 
         manager::write_frame(&mut handle, &d)?;
 
         // Read the response.
-        let mut response = [0; manager::RESPONSE_SIZE];
+        let mut response = [0; usb::RESPONSE_SIZE];
         manager::read_response(&mut handle, &mut response)?;
         manager::close_device(handle, interfaces)?;
 
@@ -312,17 +313,17 @@ impl ChallengeResponse {
 
         (&mut challenge[..chall.len()]).copy_from_slice(chall);
         let d = Frame::new(challenge, command);
-        let mut buf = [0; manager::STATUS_UPDATE_PAYLOAD_SIZE];
+        let mut buf = [0; usb::STATUS_UPDATE_PAYLOAD_SIZE];
 
         manager::wait(
             &mut handle,
-            |f| !f.contains(manager::Flags::SLOT_WRITE_FLAG),
+            |f| !f.contains(usb::Flags::SLOT_WRITE_FLAG),
             &mut buf,
         )?;
 
         manager::write_frame(&mut handle, &d)?;
 
-        let mut response = [0; manager::RESPONSE_SIZE];
+        let mut response = [0; usb::RESPONSE_SIZE];
         manager::read_response(&mut handle, &mut response)?;
         manager::close_device(handle, interfaces)?;
 

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -1,0 +1,42 @@
+use config::Command;
+use sec::crc16;
+
+/// The size of the payload when writing a request to the usb interface.
+pub(crate) const PAYLOAD_SIZE: usize = 64;
+/// The size of the response after writing a request to the usb interface.
+pub(crate) const RESPONSE_SIZE: usize = 36;
+/// The size of the payload to change the state of the device
+pub(crate) const STATUS_UPDATE_PAYLOAD_SIZE: usize = 8;
+
+pub(crate) const HID_GET_REPORT: u8 = 0x01;
+pub(crate) const HID_SET_REPORT: u8 = 0x09;
+pub(crate) const REPORT_TYPE_FEATURE: u16 = 0x03;
+
+bitflags! {
+    pub struct Flags: u8 {
+        const SLOT_WRITE_FLAG = 0x80;
+        const RESP_PENDING_FLAG = 0x40;
+    }
+}
+
+#[repr(C)]
+#[repr(packed)]
+pub struct Frame {
+    pub payload: [u8; PAYLOAD_SIZE],
+    command: Command,
+    crc: u16,
+    filler: [u8; 3],
+}
+
+impl Frame {
+    pub fn new(payload: [u8; PAYLOAD_SIZE], command: Command) -> Self {
+        let mut f = Frame {
+            payload,
+            command,
+            crc: 0,
+            filler: [0; 3],
+        };
+        f.crc = crc16(&f.payload).to_le();
+        f
+    }
+}


### PR DESCRIPTION
These components will be used by both the `rusb` and the `nusb` implementations, so I'm moving them to a separate module.