### PR TITLE
docs: mark readme examples as Rust snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ challenge_response = "0"
 If you are using a YubiKey, you can configure the HMAC-SHA1 Challenge-Response
 with the [Yubikey Personalization GUI](https://developers.yubico.com/yubikey-personalization-gui/).
 
-```rust
+```rust,ignore
 extern crate challenge_response;
 extern crate hex;
 
@@ -99,7 +99,7 @@ fn main() {
 Note, please read about the [initial configuration](https://wiki.archlinux.org/index.php/yubikey#Initial_configuration)
 Alternatively you can configure the yubikey with the official [Yubikey Personalization GUI](https://developers.yubico.com/yubikey-personalization-gui/).
 
-```ignore
+```rust,ignore
 extern crate challenge_response;
 extern crate rand;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,3 +338,38 @@ impl ChallengeResponse {
         Ok(block)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_device() {
+        let mut cr_client = match ChallengeResponse::new() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("{:?}", e);
+                return;
+            }
+        };
+
+        if let Err(e) = cr_client.find_device() {
+            assert!(matches!(e, ChallengeResponseError::DeviceNotFound));
+        };
+    }
+
+    #[test]
+    fn test_find_all_devices() {
+        let mut cr_client = match ChallengeResponse::new() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("{:?}", e);
+                return;
+            }
+        };
+
+        if let Err(e) = cr_client.find_all_devices() {
+            assert!(matches!(e, ChallengeResponseError::DeviceNotFound));
+        };
+    }
+}


### PR DESCRIPTION
I'm also adding two very basic integration tests to keep the code coverage above 0% :sweat_smile: 