### PR TITLE
refactor: create a usb backend trait

### DIFF
--- a/src/usb.rs
+++ b/src/usb.rs
@@ -1,7 +1,3 @@
-#[cfg(all(feature = "nusb", not(feature = "rusb")))]
-use nusb::Device;
-#[cfg(feature = "rusb")]
-use rusb::{Context as RUSBContext, DeviceHandle as RUSBDeviceHandle};
 use std::time::Duration;
 use std::{slice, thread};
 
@@ -9,20 +5,32 @@ use config::Command;
 use error::ChallengeResponseError;
 use sec::crc16;
 
-#[cfg(all(feature = "nusb", not(feature = "rusb")))]
-mod nusb;
 #[cfg(feature = "rusb")]
-mod rusb;
+pub type BackendType = rusb::RUSBBackend;
+#[cfg(all(feature = "nusb", not(feature = "rusb")))]
+pub type BackendType = nusb::NUSBBackend;
+
+/// If using a variable-length challenge, the challenge must be stricly smaller than this value.
+/// If using a fixed-length challenge, the challenge must be exactly equal to this value.
+pub const CHALLENGE_SIZE: usize = 64;
+
+const VENDOR_ID: [u16; 3] = [
+    0x1050, // Yubico ( Yubikeys )
+    0x1D50, // OpenMoko ( Onlykey )
+    0x20A0, // Flirc ( Nitrokey )
+];
+const PRODUCT_ID: [u16; 11] = [
+    0x0010, // YubiKey Gen 1 & 2
+    0x0110, 0x0113, 0x0114, 0x0116, // YubiKey NEO
+    0x0401, 0x0403, 0x0405, 0x0407, // Yubikey 4 & 5
+    0x60FC, // Onlykey
+    0x4211, // NitroKey
+];
 
 #[cfg(all(feature = "nusb", not(feature = "rusb")))]
-use usb::nusb::{raw_write, read};
+pub mod nusb;
 #[cfg(feature = "rusb")]
-use usb::rusb::{raw_write, read};
-
-#[cfg(all(feature = "nusb", not(feature = "rusb")))]
-pub use usb::nusb::{close_device, open_device};
-#[cfg(feature = "rusb")]
-pub use usb::rusb::{close_device, open_device};
+pub mod rusb;
 
 /// The size of the payload when writing a request to the usb interface.
 pub(crate) const PAYLOAD_SIZE: usize = 64;
@@ -66,90 +74,120 @@ impl Frame {
     }
 }
 
-#[cfg(feature = "rusb")]
-pub type Context = RUSBContext;
-#[cfg(all(feature = "nusb", not(feature = "rusb")))]
-pub type Context = ();
+#[derive(Clone, Debug, PartialEq)]
+pub struct Device {
+    pub name: Option<String>,
+    pub serial: Option<u32>,
+    pub product_id: u16,
+    pub vendor_id: u16,
+    pub bus_id: u8,
+    pub address_id: u8,
+}
 
-#[cfg(feature = "rusb")]
-pub(crate) type DeviceHandle = RUSBDeviceHandle<Context>;
-#[cfg(all(feature = "nusb", not(feature = "rusb")))]
-pub(crate) type DeviceHandle = Device;
+pub trait Backend<DeviceHandle, Interface> {
+    fn new() -> Result<Self, ChallengeResponseError>
+    where
+        Self: Sized;
 
-pub fn write_frame(handle: &mut DeviceHandle, frame: &Frame) -> Result<(), ChallengeResponseError> {
-    let mut data = unsafe { slice::from_raw_parts(frame as *const Frame as *const u8, 70) };
+    fn open_device(
+        &mut self,
+        bus_id: u8,
+        address_id: u8,
+    ) -> Result<(DeviceHandle, Vec<Interface>), ChallengeResponseError>;
 
-    let mut seq = 0;
-    let mut buf = [0; 8];
-    while !data.is_empty() {
-        let (a, b) = data.split_at(7);
+    fn close_device(
+        &self,
+        handle: DeviceHandle,
+        interfaces: Vec<Interface>,
+    ) -> Result<(), ChallengeResponseError>;
 
-        if seq == 0 || b.is_empty() || a.iter().any(|&x| x != 0) {
-            let mut packet = [0; 8];
-            (&mut packet[..7]).copy_from_slice(a);
+    fn read(&self, handle: &mut DeviceHandle, buf: &mut [u8]) -> Result<usize, ChallengeResponseError>;
+    fn raw_write(&self, handle: &mut DeviceHandle, packet: &[u8]) -> Result<(), ChallengeResponseError>;
 
-            packet[7] = Flags::SLOT_WRITE_FLAG.bits() + seq;
-            wait(handle, |x| !x.contains(Flags::SLOT_WRITE_FLAG), &mut buf)?;
-            raw_write(handle, &packet)?;
+    fn find_device(&mut self) -> Result<Device, ChallengeResponseError>;
+    fn find_device_from_serial(&mut self, serial: u32) -> Result<Device, ChallengeResponseError>;
+    fn find_all_devices(&mut self) -> Result<Vec<Device>, ChallengeResponseError>;
+
+    fn write_frame(&self, handle: &mut DeviceHandle, frame: &Frame) -> Result<(), ChallengeResponseError> {
+        let mut data = unsafe { slice::from_raw_parts(frame as *const Frame as *const u8, 70) };
+
+        let mut seq = 0;
+        let mut buf = [0; 8];
+        while !data.is_empty() {
+            let (a, b) = data.split_at(7);
+
+            if seq == 0 || b.is_empty() || a.iter().any(|&x| x != 0) {
+                let mut packet = [0; 8];
+                (&mut packet[..7]).copy_from_slice(a);
+
+                packet[7] = Flags::SLOT_WRITE_FLAG.bits() + seq;
+                self.wait(handle, |x| !x.contains(Flags::SLOT_WRITE_FLAG), &mut buf)?;
+                self.raw_write(handle, &packet)?;
+            }
+            data = b;
+            seq += 1
         }
-        data = b;
-        seq += 1
+        Ok(())
     }
-    Ok(())
-}
 
-pub fn wait<F: Fn(Flags) -> bool>(
-    handle: &mut DeviceHandle,
-    f: F,
-    buf: &mut [u8],
-) -> Result<(), ChallengeResponseError> {
-    loop {
-        read(handle, buf)?;
-        let flags = Flags::from_bits_truncate(buf[7]);
-        if flags.contains(Flags::SLOT_WRITE_FLAG) || flags.is_empty() {
-            // Should store the version
-        }
+    fn wait<F: Fn(Flags) -> bool>(
+        &self,
+        handle: &mut DeviceHandle,
+        f: F,
+        buf: &mut [u8],
+    ) -> Result<(), ChallengeResponseError> {
+        loop {
+            self.read(handle, buf)?;
+            let flags = Flags::from_bits_truncate(buf[7]);
+            if flags.contains(Flags::SLOT_WRITE_FLAG) || flags.is_empty() {
+                // Should store the version
+            }
 
-        if f(flags) {
-            return Ok(());
+            if f(flags) {
+                return Ok(());
+            }
+            thread::sleep(Duration::new(0, 1000000));
         }
-        thread::sleep(Duration::new(0, 1000000));
     }
-}
 
-/// Reset the write state after a read.
-pub fn write_reset(handle: &mut DeviceHandle) -> Result<(), ChallengeResponseError> {
-    raw_write(handle, &WRITE_RESET_PAYLOAD)?;
-    let mut buf = [0; 8];
-    wait(handle, |x| !x.contains(Flags::SLOT_WRITE_FLAG), &mut buf)?;
-    Ok(())
-}
+    /// Reset the write state after a read.
+    fn write_reset(&self, handle: &mut DeviceHandle) -> Result<(), ChallengeResponseError> {
+        self.raw_write(handle, &WRITE_RESET_PAYLOAD)?;
+        let mut buf = [0; 8];
+        self.wait(handle, |x| !x.contains(Flags::SLOT_WRITE_FLAG), &mut buf)?;
+        Ok(())
+    }
 
-pub fn read_response(handle: &mut DeviceHandle, response: &mut [u8]) -> Result<usize, ChallengeResponseError> {
-    let mut r0 = 0;
-    wait(
-        handle,
-        |f| f.contains(Flags::RESP_PENDING_FLAG),
-        &mut response[..8],
-    )?;
-    r0 += 7;
-    loop {
-        if read(handle, &mut response[r0..r0 + 8])? < 8 {
-            break;
-        }
-        let flags = Flags::from_bits_truncate(response[r0 + 7]);
-        if flags.contains(Flags::RESP_PENDING_FLAG) {
-            let seq = response[r0 + 7] & 0b00011111;
-            if r0 > 0 && seq == 0 {
-                // If the sequence number is 0, and we have read at
-                // least one packet, stop.
+    fn read_response(
+        &self,
+        handle: &mut DeviceHandle,
+        response: &mut [u8],
+    ) -> Result<usize, ChallengeResponseError> {
+        let mut r0 = 0;
+        self.wait(
+            handle,
+            |f| f.contains(Flags::RESP_PENDING_FLAG),
+            &mut response[..8],
+        )?;
+        r0 += 7;
+        loop {
+            if self.read(handle, &mut response[r0..r0 + 8])? < 8 {
                 break;
             }
-        } else {
-            break;
+            let flags = Flags::from_bits_truncate(response[r0 + 7]);
+            if flags.contains(Flags::RESP_PENDING_FLAG) {
+                let seq = response[r0 + 7] & 0b00011111;
+                if r0 > 0 && seq == 0 {
+                    // If the sequence number is 0, and we have read at
+                    // least one packet, stop.
+                    break;
+                }
+            } else {
+                break;
+            }
+            r0 += 7;
         }
-        r0 += 7;
+        self.write_reset(handle)?;
+        Ok(r0)
     }
-    write_reset(handle)?;
-    Ok(r0)
 }

--- a/src/usb/nusb.rs
+++ b/src/usb/nusb.rs
@@ -1,87 +1,177 @@
+use nusb::{Device as NUSBDevice, Interface};
+
 use error::ChallengeResponseError;
-use nusb::Interface;
 use std::time::Duration;
-use usb::{DeviceHandle, HID_GET_REPORT, HID_SET_REPORT, REPORT_TYPE_FEATURE};
+use usb::{Backend, Device, HID_GET_REPORT, HID_SET_REPORT, PRODUCT_ID, REPORT_TYPE_FEATURE, VENDOR_ID};
 
-pub fn open_device(
-    _context: &mut (),
-    bus_id: u8,
-    address_id: u8,
-) -> Result<(DeviceHandle, Vec<Interface>), ChallengeResponseError> {
-    let nusb_devices = match nusb::list_devices() {
-        Ok(d) => d,
-        Err(e) => return Err(e.into()),
-    };
-    for device_info in nusb_devices {
-        if device_info.bus_number() != bus_id || device_info.device_address() != address_id {
-            continue;
-        }
+pub struct NUSBBackend {}
 
-        let device = match device_info.open() {
+impl Backend<NUSBDevice, Interface> for NUSBBackend {
+    fn new() -> Result<Self, ChallengeResponseError> {
+        Ok(Self {})
+    }
+
+    fn open_device(
+        &mut self,
+        bus_id: u8,
+        address_id: u8,
+    ) -> Result<(NUSBDevice, Vec<Interface>), ChallengeResponseError> {
+        let nusb_devices = match nusb::list_devices() {
             Ok(d) => d,
-            Err(_) => {
-                return Err(ChallengeResponseError::OpenDeviceError);
-            }
+            Err(e) => return Err(e.into()),
         };
+        for device_info in nusb_devices {
+            if device_info.bus_number() != bus_id || device_info.device_address() != address_id {
+                continue;
+            }
 
-        let mut interfaces: Vec<Interface> = Vec::new();
-        for interface in device_info.interfaces() {
-            let interface = match device.detach_and_claim_interface(interface.interface_number()) {
-                Ok(interface) => interface,
-                Err(_) => continue,
+            let device = match device_info.open() {
+                Ok(d) => d,
+                Err(_) => {
+                    return Err(ChallengeResponseError::OpenDeviceError);
+                }
             };
 
-            interfaces.push(interface);
+            let mut interfaces: Vec<Interface> = Vec::new();
+            for interface in device_info.interfaces() {
+                let interface = match device.detach_and_claim_interface(interface.interface_number()) {
+                    Ok(interface) => interface,
+                    Err(_) => continue,
+                };
+
+                interfaces.push(interface);
+            }
+            return Ok((device, interfaces));
         }
-        return Ok((device, interfaces));
+
+        Err(ChallengeResponseError::DeviceNotFound)
     }
 
-    Err(ChallengeResponseError::DeviceNotFound)
-}
-
-pub fn close_device(
-    mut _handle: DeviceHandle,
-    _interfaces: Vec<Interface>,
-) -> Result<(), ChallengeResponseError> {
-    Ok(())
-}
-
-pub fn read(handle: &mut DeviceHandle, buf: &mut [u8]) -> Result<usize, ChallengeResponseError> {
-    assert_eq!(buf.len(), 8);
-
-    let control_type = nusb::transfer::ControlType::Class;
-    let control_in = nusb::transfer::Control {
-        control_type,
-        recipient: nusb::transfer::Recipient::Interface,
-        request: HID_GET_REPORT,
-        value: REPORT_TYPE_FEATURE << 8,
-        index: 0,
-    };
-
-    match handle.control_in_blocking(control_in, buf, Duration::new(2, 0)) {
-        Ok(r) => Ok(r),
-        Err(_e) => Err(ChallengeResponseError::CanNotReadFromDevice),
+    fn close_device(
+        &self,
+        mut _handle: NUSBDevice,
+        _interfaces: Vec<Interface>,
+    ) -> Result<(), ChallengeResponseError> {
+        Ok(())
     }
-}
 
-pub fn raw_write(handle: &mut DeviceHandle, packet: &[u8]) -> Result<(), ChallengeResponseError> {
-    let control_type = nusb::transfer::ControlType::Class;
-    let control_out = nusb::transfer::Control {
-        control_type,
-        recipient: nusb::transfer::Recipient::Interface,
-        request: HID_SET_REPORT,
-        value: REPORT_TYPE_FEATURE << 8,
-        index: 0,
-    };
+    fn read(&self, handle: &mut NUSBDevice, buf: &mut [u8]) -> Result<usize, ChallengeResponseError> {
+        assert_eq!(buf.len(), 8);
 
-    match handle.control_out_blocking(control_out, packet, Duration::new(2, 0)) {
-        Ok(bytes_written) => {
-            if bytes_written != 8 {
-                Err(ChallengeResponseError::CanNotWriteToDevice)
-            } else {
-                Ok(())
+        let control_type = nusb::transfer::ControlType::Class;
+        let control_in = nusb::transfer::Control {
+            control_type,
+            recipient: nusb::transfer::Recipient::Interface,
+            request: HID_GET_REPORT,
+            value: REPORT_TYPE_FEATURE << 8,
+            index: 0,
+        };
+
+        match handle.control_in_blocking(control_in, buf, Duration::new(2, 0)) {
+            Ok(r) => Ok(r),
+            Err(_e) => Err(ChallengeResponseError::CanNotReadFromDevice),
+        }
+    }
+
+    fn raw_write(&self, handle: &mut NUSBDevice, packet: &[u8]) -> Result<(), ChallengeResponseError> {
+        let control_type = nusb::transfer::ControlType::Class;
+        let control_out = nusb::transfer::Control {
+            control_type,
+            recipient: nusb::transfer::Recipient::Interface,
+            request: HID_SET_REPORT,
+            value: REPORT_TYPE_FEATURE << 8,
+            index: 0,
+        };
+
+        match handle.control_out_blocking(control_out, packet, Duration::new(2, 0)) {
+            Ok(bytes_written) => {
+                if bytes_written != 8 {
+                    Err(ChallengeResponseError::CanNotWriteToDevice)
+                } else {
+                    Ok(())
+                }
+            }
+            Err(_) => Err(ChallengeResponseError::CanNotWriteToDevice),
+        }
+    }
+
+    fn find_device(&mut self) -> Result<Device, ChallengeResponseError> {
+        match self.find_all_devices() {
+            Ok(devices) => {
+                if !devices.is_empty() {
+                    Ok(devices[0].clone())
+                } else {
+                    Err(ChallengeResponseError::DeviceNotFound)
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn find_device_from_serial(&mut self, serial: u32) -> Result<Device, ChallengeResponseError> {
+        let nusb_devices = nusb::list_devices()?;
+        for device_info in nusb_devices {
+            let product_id = device_info.product_id();
+            let vendor_id = device_info.vendor_id();
+
+            if !VENDOR_ID.contains(&vendor_id) || !PRODUCT_ID.contains(&product_id) {
+                continue;
+            }
+
+            let device_serial = match device_info.serial_number() {
+                Some(s) => match s.parse::<u32>() {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                },
+                None => continue,
+            };
+
+            if device_serial == serial {
+                return Ok(Device {
+                    name: match device_info.manufacturer_string() {
+                        Some(name) => Some(name.to_string()),
+                        None => Some("unknown".to_string()),
+                    },
+                    serial: Some(serial),
+                    product_id,
+                    vendor_id,
+                    bus_id: device_info.bus_number(),
+                    address_id: device_info.device_address(),
+                });
             }
         }
-        Err(_) => Err(ChallengeResponseError::CanNotWriteToDevice),
+        Err(ChallengeResponseError::DeviceNotFound)
+    }
+
+    fn find_all_devices(&mut self) -> Result<Vec<Device>, ChallengeResponseError> {
+        let mut devices: Vec<Device> = Vec::new();
+        let nusb_devices = nusb::list_devices()?;
+        for device_info in nusb_devices {
+            let product_id = device_info.product_id();
+            let vendor_id = device_info.vendor_id();
+
+            if !VENDOR_ID.contains(&vendor_id) || !PRODUCT_ID.contains(&product_id) {
+                continue;
+            }
+
+            devices.push(Device {
+                name: match device_info.manufacturer_string() {
+                    Some(name) => Some(name.to_string()),
+                    None => Some("unknown".to_string()),
+                },
+                serial: match device_info.serial_number() {
+                    Some(serial) => match serial.parse::<u32>() {
+                        Ok(s) => Some(s),
+                        Err(_) => None,
+                    },
+                    None => None,
+                },
+                product_id,
+                vendor_id,
+                bus_id: device_info.bus_number(),
+                address_id: device_info.device_address(),
+            });
+        }
+        Ok(devices)
     }
 }

--- a/src/usb/rusb.rs
+++ b/src/usb/rusb.rs
@@ -1,96 +1,259 @@
 use error::ChallengeResponseError;
-use rusb::{request_type, Context, Direction, Recipient, RequestType, UsbContext};
+use rusb::{
+    request_type, Context, Device as RUSBDevice, DeviceHandle, Direction, Recipient, RequestType, UsbContext,
+};
+use sec::crc16;
 use std::time::Duration;
-use usb::{DeviceHandle, HID_GET_REPORT, HID_SET_REPORT, REPORT_TYPE_FEATURE};
+use usb::{
+    Backend, Command, Device, Flags, Frame, CHALLENGE_SIZE, HID_GET_REPORT, HID_SET_REPORT, PRODUCT_ID,
+    REPORT_TYPE_FEATURE, RESPONSE_SIZE, STATUS_UPDATE_PAYLOAD_SIZE, VENDOR_ID,
+};
 
-pub fn open_device(
-    context: &mut Context,
-    bus_id: u8,
-    address_id: u8,
-) -> Result<(DeviceHandle, Vec<u8>), ChallengeResponseError> {
-    let devices = match context.devices() {
-        Ok(device) => device,
-        Err(_) => {
-            return Err(ChallengeResponseError::DeviceNotFound);
-        }
-    };
+pub struct RUSBBackend {
+    context: Context,
+}
 
-    for device in devices.iter() {
-        match device.device_descriptor() {
-            Ok(_) => {}
+impl Backend<DeviceHandle<Context>, u8> for RUSBBackend {
+    fn new() -> Result<Self, ChallengeResponseError> {
+        let context = match Context::new() {
+            Ok(c) => c,
+            Err(e) => return Err(ChallengeResponseError::UsbError(e)),
+        };
+        Ok(Self { context })
+    }
+
+    fn open_device(
+        &mut self,
+        bus_id: u8,
+        address_id: u8,
+    ) -> Result<(DeviceHandle<Context>, Vec<u8>), ChallengeResponseError> {
+        let devices = match self.context.devices() {
+            Ok(device) => device,
             Err(_) => {
                 return Err(ChallengeResponseError::DeviceNotFound);
             }
         };
 
-        if device.bus_number() == bus_id && device.address() == address_id {
-            match device.open() {
-                Ok(handle) => {
-                    let config = match device.config_descriptor(0) {
-                        Ok(c) => c,
-                        Err(_) => continue,
-                    };
-
-                    let mut _interfaces = Vec::new();
-                    for interface in config.interfaces() {
-                        for usb_int in interface.descriptors() {
-                            match handle.kernel_driver_active(usb_int.interface_number()) {
-                                Ok(true) => {
-                                    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-                                    handle.detach_kernel_driver(usb_int.interface_number())?;
-                                }
-                                _ => continue,
-                            };
-
-                            if handle.active_configuration()? != config.number() {
-                                handle.set_active_configuration(config.number())?;
-                            }
-                            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-                            handle.claim_interface(usb_int.interface_number())?;
-                            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-                            _interfaces.push(usb_int.interface_number());
-                        }
-                    }
-
-                    return Ok((handle, _interfaces));
-                }
+        for device in devices.iter() {
+            match device.device_descriptor() {
+                Ok(_) => {}
                 Err(_) => {
-                    return Err(ChallengeResponseError::OpenDeviceError);
+                    return Err(ChallengeResponseError::DeviceNotFound);
+                }
+            };
+
+            if device.bus_number() == bus_id && device.address() == address_id {
+                match device.open() {
+                    Ok(handle) => {
+                        let config = match device.config_descriptor(0) {
+                            Ok(c) => c,
+                            Err(_) => continue,
+                        };
+
+                        let mut _interfaces = Vec::new();
+                        for interface in config.interfaces() {
+                            for usb_int in interface.descriptors() {
+                                match handle.kernel_driver_active(usb_int.interface_number()) {
+                                    Ok(true) => {
+                                        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+                                        handle.detach_kernel_driver(usb_int.interface_number())?;
+                                    }
+                                    _ => continue,
+                                };
+
+                                if handle.active_configuration()? != config.number() {
+                                    handle.set_active_configuration(config.number())?;
+                                }
+                                #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+                                handle.claim_interface(usb_int.interface_number())?;
+                                #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+                                _interfaces.push(usb_int.interface_number());
+                            }
+                        }
+
+                        return Ok((handle, _interfaces));
+                    }
+                    Err(_) => {
+                        return Err(ChallengeResponseError::OpenDeviceError);
+                    }
                 }
             }
         }
+
+        Err(ChallengeResponseError::DeviceNotFound)
     }
 
-    Err(ChallengeResponseError::DeviceNotFound)
-}
-
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-pub fn close_device(_handle: DeviceHandle, _interfaces: Vec<u8>) -> Result<(), ChallengeResponseError> {
-    Ok(())
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-pub fn close_device(handle: DeviceHandle, interfaces: Vec<u8>) -> Result<(), ChallengeResponseError> {
-    for interface in interfaces {
-        handle.release_interface(interface)?;
-        handle.attach_kernel_driver(interface)?;
-    }
-    Ok(())
-}
-
-pub fn read(handle: &mut DeviceHandle, buf: &mut [u8]) -> Result<usize, ChallengeResponseError> {
-    assert_eq!(buf.len(), 8);
-    let reqtype = request_type(Direction::In, RequestType::Class, Recipient::Interface);
-    let value = REPORT_TYPE_FEATURE << 8;
-    Ok(handle.read_control(reqtype, HID_GET_REPORT, value, 0, buf, Duration::new(2, 0))?)
-}
-
-pub fn raw_write(handle: &mut DeviceHandle, packet: &[u8]) -> Result<(), ChallengeResponseError> {
-    let reqtype = request_type(Direction::Out, RequestType::Class, Recipient::Interface);
-    let value = REPORT_TYPE_FEATURE << 8;
-    if handle.write_control(reqtype, HID_SET_REPORT, value, 0, &packet, Duration::new(2, 0))? != 8 {
-        Err(ChallengeResponseError::CanNotWriteToDevice)
-    } else {
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn close_device(
+        &self,
+        mut handle: DeviceHandle<Context>,
+        interfaces: Vec<u8>,
+    ) -> Result<(), ChallengeResponseError> {
         Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    fn close_device(
+        &self,
+        handle: DeviceHandle<Context>,
+        interfaces: Vec<u8>,
+    ) -> Result<(), ChallengeResponseError> {
+        for interface in interfaces {
+            handle.release_interface(interface)?;
+            handle.attach_kernel_driver(interface)?;
+        }
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        handle: &mut DeviceHandle<Context>,
+        buf: &mut [u8],
+    ) -> Result<usize, ChallengeResponseError> {
+        assert_eq!(buf.len(), 8);
+        let reqtype = request_type(Direction::In, RequestType::Class, Recipient::Interface);
+        let value = REPORT_TYPE_FEATURE << 8;
+        Ok(handle.read_control(reqtype, HID_GET_REPORT, value, 0, buf, Duration::new(2, 0))?)
+    }
+
+    fn raw_write(
+        &self,
+        handle: &mut DeviceHandle<Context>,
+        packet: &[u8],
+    ) -> Result<(), ChallengeResponseError> {
+        let reqtype = request_type(Direction::Out, RequestType::Class, Recipient::Interface);
+        let value = REPORT_TYPE_FEATURE << 8;
+        if handle.write_control(reqtype, HID_SET_REPORT, value, 0, &packet, Duration::new(2, 0))? != 8 {
+            Err(ChallengeResponseError::CanNotWriteToDevice)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn find_device(&mut self) -> Result<Device, ChallengeResponseError> {
+        let devices = match self.context.devices() {
+            Ok(d) => d,
+            Err(e) => return Err(ChallengeResponseError::UsbError(e)),
+        };
+        for device in devices.iter() {
+            let descr = device
+                .device_descriptor()
+                .map_err(|e| ChallengeResponseError::UsbError(e))?;
+            if !VENDOR_ID.contains(&descr.vendor_id()) || !PRODUCT_ID.contains(&descr.product_id()) {
+                continue;
+            }
+
+            let name = device.open()?.read_product_string_ascii(&descr).ok();
+            let serial = self.read_serial_from_device(device.clone()).ok();
+            let device = Device {
+                name,
+                serial,
+                product_id: descr.product_id(),
+                vendor_id: descr.vendor_id(),
+                bus_id: device.bus_number(),
+                address_id: device.address(),
+            };
+
+            return Ok(device);
+        }
+
+        Err(ChallengeResponseError::DeviceNotFound)
+    }
+
+    fn find_device_from_serial(&mut self, serial: u32) -> Result<Device, ChallengeResponseError> {
+        let devices = match self.context.devices() {
+            Ok(d) => d,
+            Err(e) => return Err(ChallengeResponseError::UsbError(e)),
+        };
+        for device in devices.iter() {
+            let descr = device
+                .device_descriptor()
+                .map_err(|e| ChallengeResponseError::UsbError(e))?;
+            if !VENDOR_ID.contains(&descr.vendor_id()) || !PRODUCT_ID.contains(&descr.product_id()) {
+                continue;
+            }
+
+            let name = device.open()?.read_product_string_ascii(&descr).ok();
+            let fetched_serial = match self.read_serial_from_device(device.clone()).ok() {
+                Some(s) => s,
+                None => 0,
+            };
+            if serial == fetched_serial {
+                let device = Device {
+                    name,
+                    serial: Some(serial),
+                    product_id: descr.product_id(),
+                    vendor_id: descr.vendor_id(),
+                    bus_id: device.bus_number(),
+                    address_id: device.address(),
+                };
+
+                return Ok(device);
+            }
+        }
+
+        Err(ChallengeResponseError::DeviceNotFound)
+    }
+
+    fn find_all_devices(&mut self) -> Result<Vec<Device>, ChallengeResponseError> {
+        let mut result: Vec<Device> = Vec::new();
+        let devices = match self.context.devices() {
+            Ok(d) => d,
+            Err(e) => return Err(ChallengeResponseError::UsbError(e)),
+        };
+        for device in devices.iter() {
+            let descr = device
+                .device_descriptor()
+                .map_err(|e| ChallengeResponseError::UsbError(e))?;
+            if !VENDOR_ID.contains(&descr.vendor_id()) || !PRODUCT_ID.contains(&descr.product_id()) {
+                continue;
+            }
+
+            let name = device.open()?.read_product_string_ascii(&descr).ok();
+            let serial = self.read_serial_from_device(device.clone()).ok();
+            let device = Device {
+                name,
+                serial,
+                product_id: descr.product_id(),
+                vendor_id: descr.vendor_id(),
+                bus_id: device.bus_number(),
+                address_id: device.address(),
+            };
+            result.push(device);
+        }
+
+        if !result.is_empty() {
+            return Ok(result);
+        }
+
+        Err(ChallengeResponseError::DeviceNotFound)
+    }
+}
+
+impl RUSBBackend {
+    fn read_serial_from_device(&mut self, device: RUSBDevice<Context>) -> Result<u32, ChallengeResponseError> {
+        let (mut handle, interfaces) = self.open_device(device.bus_number(), device.address())?;
+        let challenge = [0; CHALLENGE_SIZE];
+        let command = Command::DeviceSerial;
+
+        let d = Frame::new(challenge, command); // FixMe: do not need a challange
+        let mut buf = [0; STATUS_UPDATE_PAYLOAD_SIZE];
+        self.wait(&mut handle, |f| !f.contains(Flags::SLOT_WRITE_FLAG), &mut buf)?;
+
+        self.write_frame(&mut handle, &d)?;
+
+        // Read the response.
+        let mut response = [0; RESPONSE_SIZE];
+        self.read_response(&mut handle, &mut response)?;
+        self.close_device(handle, interfaces)?;
+
+        // Check response.
+        if crc16(&response[..6]) != crate::sec::CRC_RESIDUAL_OK {
+            return Err(ChallengeResponseError::WrongCRC);
+        }
+
+        let serial = structure!("2I").unpack(response[..8].to_vec())?;
+
+        Ok(serial.0)
     }
 }


### PR DESCRIPTION
This commit creates a `Backend` trait that encapsulates all the functions that are specific to a backend (`rusb` or `nusb`). This has the following advantages:
* All the backend-specific code is out of `src/lib.rs` and moved into the `usb` module and submodules.
* The number of `cfg` compilation directives is reduced drastically
* It will be easier to change the backend dynamically by changing which trait object is used as a backend
* It will also be easier to unit test the non-backend part of the codebase, by creating a `MockBackend`.

I'm not able to implement the dynamic backend feature at the moment, since I need to find a way to deal with [the requirements for trait objects in Rust](https://doc.rust-lang.org/reference/items/traits.html#object-safety). This can definitely happen in a future PR.