### PR TITLE
feat: add a ci job for windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,26 @@ jobs:
             rustfmt --check "$file"
           done
 
+  build-windows:
+    name: Build the project (Windows)
+    runs-on: windows-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Build the project with all the features
+        run: cargo build --all-features
+
+      - name: Build the project with nusb support
+        run: cargo build --no-default-features --features nusb
+
+      - name: Build the examples
+        run: cargo build --examples
+
   build:
     name: Build the project
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,18 @@ default = ["rusb"]
 [dependencies]
 rand = "0.9"
 bitflags = "2.4"
-rusb = { version = "0.9", optional = true }
-nusb = { version = "0.1", optional = true }
 structure = "0.1"
 aes = "0.8"
 block-modes = "0.9"
 hmac = "0.12"
 sha-1 = "0.10"
+
+[target.'cfg(windows)'.dependencies]
+rusb = { version = "0.9" }
+
+[target.'cfg(not(windows))'.dependencies]
+rusb = { version = "0.9", optional = true }
+nusb = { version = "0.1", optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ challenge_response = { version = "0", default-features = false, features = ["nus
 The `nusb` backend has the advantage of not depending on `libusb`, thus making it easier to add
 `challenge_response` to your dependencies.
 
+> [!NOTE]
+> The `nusb` feature is not available on Windows. If configured, the library will default to using the `rusb` backend instead.
+
 ### Perform a Challenge-Response (HMAC-SHA1 mode)
 
 If you are using a YubiKey, you can configure the HMAC-SHA1 Challenge-Response

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "rusb")]
+#[cfg(any(feature = "rusb", target_os = "windows"))]
 use rusb::Error as usbError;
 use std::error;
 use std::fmt;
@@ -7,7 +7,7 @@ use std::io::Error as ioError;
 #[derive(Debug)]
 pub enum ChallengeResponseError {
     IOError(ioError),
-    #[cfg(feature = "rusb")]
+    #[cfg(any(feature = "rusb", target_os = "windows"))]
     UsbError(usbError),
     CommandNotSupported,
     DeviceNotFound,
@@ -23,7 +23,7 @@ impl fmt::Display for ChallengeResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ChallengeResponseError::IOError(ref err) => write!(f, "IO error: {}", err),
-            #[cfg(feature = "rusb")]
+            #[cfg(any(feature = "rusb", target_os = "windows"))]
             ChallengeResponseError::UsbError(ref err) => write!(f, "USB  error: {}", err),
             ChallengeResponseError::DeviceNotFound => write!(f, "Device not found"),
             ChallengeResponseError::OpenDeviceError => write!(f, "Can not open device"),
@@ -40,7 +40,7 @@ impl fmt::Display for ChallengeResponseError {
 impl error::Error for ChallengeResponseError {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
-            #[cfg(feature = "rusb")]
+            #[cfg(any(feature = "rusb", target_os = "windows"))]
             ChallengeResponseError::UsbError(ref err) => Some(err),
             _ => None,
         }
@@ -53,7 +53,7 @@ impl From<ioError> for ChallengeResponseError {
     }
 }
 
-#[cfg(feature = "rusb")]
+#[cfg(any(feature = "rusb", target_os = "windows"))]
 impl From<usbError> for ChallengeResponseError {
     fn from(err: usbError) -> ChallengeResponseError {
         ChallengeResponseError::UsbError(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,9 @@
 #[cfg(not(any(feature = "rusb", feature = "nusb")))]
 compile_error!("Either the rusb or nusb feature must be enabled for this crate");
 
-#[cfg(feature = "nusb")]
+#[cfg(all(feature = "nusb", not(feature = "rusb"), not(target_os = "windows")))]
 extern crate nusb;
-#[cfg(feature = "rusb")]
+#[cfg(any(feature = "rusb", target_os = "windows"))]
 extern crate rusb;
 
 #[macro_use]

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -5,9 +5,9 @@ use config::Command;
 use error::ChallengeResponseError;
 use sec::crc16;
 
-#[cfg(feature = "rusb")]
+#[cfg(any(feature = "rusb", target_os = "windows"))]
 pub type BackendType = rusb::RUSBBackend;
-#[cfg(all(feature = "nusb", not(feature = "rusb")))]
+#[cfg(all(feature = "nusb", not(feature = "rusb"), not(target_os = "windows")))]
 pub type BackendType = nusb::NUSBBackend;
 
 /// If using a variable-length challenge, the challenge must be stricly smaller than this value.
@@ -27,9 +27,9 @@ const PRODUCT_ID: [u16; 11] = [
     0x4211, // NitroKey
 ];
 
-#[cfg(all(feature = "nusb", not(feature = "rusb")))]
+#[cfg(all(feature = "nusb", not(feature = "rusb"), not(target_os = "windows")))]
 pub mod nusb;
-#[cfg(feature = "rusb")]
+#[cfg(any(feature = "rusb", target_os = "windows"))]
 pub mod rusb;
 
 /// The size of the payload when writing a request to the usb interface.

--- a/src/usb/rusb.rs
+++ b/src/usb/rusb.rs
@@ -80,8 +80,8 @@ impl Backend<DeviceHandle<Context>, u8> for RUSBBackend {
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     fn close_device(
         &self,
-        mut handle: DeviceHandle<Context>,
-        interfaces: Vec<u8>,
+        _handle: DeviceHandle<Context>,
+        _interfaces: Vec<u8>,
     ) -> Result<(), ChallengeResponseError> {
         Ok(())
     }


### PR DESCRIPTION
This will also fix the Windows builds by forcing the `rusb` backend to be used on windows, even if the `nusb` backend is selected. 